### PR TITLE
CV #2 - Initializer

### DIFF
--- a/app/controllers/controlled_vocabulary/base_controller.rb
+++ b/app/controllers/controlled_vocabulary/base_controller.rb
@@ -4,6 +4,12 @@ module ControlledVocabulary
       super *attrs.map{ |attr| attr.is_a?(Symbol) ? "#{table_name}.#{attr}" : attr }
     end
 
+    def current_user
+      return super if defined?(super)
+
+      nil
+    end
+
     def item_class
       "ControlledVocabulary::#{controller_name.singularize.classify}".constantize
     end

--- a/lib/controlled_vocabulary.rb
+++ b/lib/controlled_vocabulary.rb
@@ -3,10 +3,9 @@ require 'controlled_vocabulary/engine'
 require 'controlled_vocabulary/configuration'
 
 module ControlledVocabulary
-  mattr_accessor :config
+  mattr_accessor :config, default: Configuration.new
 
   def self.configure(&block)
-    self.config ||= Configuration.new
     block.call self.config
   end
 end


### PR DESCRIPTION
This pull request fixes an issue with the gem where an exception was thrown if the initializer was not provided by the consuming application. The solution was to simply default the value of the `config` attribute, instead of initializing it on the `configure` method.

The solution above also exposed a bug with the integration with the `resource-api` gem. If a base controller class is not provided in the configuration, the `resource-api` controller is expected a method called `current_user` to be defined (for authentication). We'll also add a `current_user` method to BaseController.